### PR TITLE
fix: include reading references for Lent days in non-detailed mode

### DIFF
--- a/apps/api/src/__tests__/models/readings.lent.test.ts
+++ b/apps/api/src/__tests__/models/readings.lent.test.ts
@@ -253,15 +253,21 @@ describe('Lenten Readings - Accuracy', () => {
 	})
 
 	describe('Detailed vs non-detailed mode', () => {
-		it('should return season info in non-detailed mode for Lent date', () => {
+		it('should return season info and reference strings in non-detailed mode for Lent date', () => {
 			const date = new Date(2026, 1, 16)
 			const result = getByCopticDate(date, false)
 
 			expect(result.season).toBe('Great Lent')
 			expect(result.seasonDay).toBe('Monday of the first week of Great Lent')
 			expect(result.Synaxarium).toBeDefined()
+			// Verse references are exposed under `reference` (like fixed days), not at top level.
 			expect(result.Pauline).toBeUndefined()
 			expect(result.LGospel).toBeUndefined()
+			expect(result.reference).toBeDefined()
+			expect(result.reference?.Pauline).toBe('Romans 1:26-2:7')
+			expect(result.reference?.LGospel).toBe('Mark 9:33-50')
+			// Moveable days have no fixed-calendar reading id.
+			expect(result.reference?.id).toBeUndefined()
 		})
 
 		it('should return full readings in detailed mode for Lent date', () => {

--- a/apps/api/src/models/readings/index.ts
+++ b/apps/api/src/models/readings/index.ts
@@ -112,8 +112,26 @@ export const transformReading = (record: ReadingRecord, translation: BibleTransl
 	}
 }
 
+// Raw verse-reference strings returned in non-detailed mode. Fixed days carry an
+// `id`; moveable (Lent/Jonah) days don't, so both fields are optional.
+type ReadingReference = {
+	id?: number
+	Prophecies?: string
+	VPsalm?: string
+	VGospel?: string
+	MPsalm?: string
+	MGospel?: string
+	Pauline?: string
+	Catholic?: string
+	Acts?: string
+	LPsalm?: string
+	LGospel?: string
+	EPPsalm?: string
+	EPGospel?: string
+}
+
 type ReadingResponse = {
-	reference?: Omit<(typeof uniqueReadings)[number], 'Day'>
+	reference?: ReadingReference
 	Synaxarium: SynaxariumEntry[]
 	Prophecies?: Reading[] | null
 	VPsalm?: Reading[] | null
@@ -185,7 +203,13 @@ const buildLentResponse = (
 ): ReadingResponse => {
 	const season = getLiturgicalSeasonForDate(date)
 	if (!isDetailed) {
-		return { Synaxarium: synaxarium, season: season?.name, seasonDay: lentReading.label }
+		const { label, ...reference } = lentReading
+		return {
+			reference,
+			Synaxarium: synaxarium,
+			season: season?.name,
+			seasonDay: lentReading.label,
+		}
 	}
 	return {
 		...transformReading(lentReading, translation),


### PR DESCRIPTION
Fixes a bug ([reported here](https://github.com/abanobmikaeel/coptic.io/issues)) where `/api/readings/:date` returned no scripture readings during Great Lent / Jonah's Fast.

**Cause:** in non-detailed mode, fixed days return verse references under `reference`, but Lent days dropped them — returning only Synaxarium and season info.

**Fix:** `buildLentResponse` now returns a `reference` object like fixed days. The data already existed in `lentReadings.json`; it just wasn't surfaced.

Tests added; all model tests pass.
