### PR TITLE
fix(web): draw verification codes and subscriber tokens from the CSPRNG

### DIFF
--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -34,6 +34,13 @@ function getShimmerClass(theme: ReadingTheme) {
 	return themeClasses.shimmer[theme]
 }
 
+/**
+ * Ragged line lengths, so a block of placeholder verses reads as text rather than
+ * as a solid slab. Fixed rather than random: this renders on the server too, and
+ * a width drawn per render would not match the one React hydrates against.
+ */
+const VERSE_WIDTHS = ['96%', '78%', '88%', '72%', '92%']
+
 export function ReadingsSkeleton({ theme = 'light' }: { theme?: ReadingTheme }) {
 	const shimmer = getShimmerClass(theme)
 
@@ -55,7 +62,7 @@ export function ReadingsSkeleton({ theme = 'light' }: { theme?: ReadingTheme }) 
 								<div className={`h-5 w-6 rounded flex-shrink-0 ${shimmer}`} />
 								<div
 									className={`h-5 flex-1 rounded ${shimmer}`}
-									style={{ width: `${70 + Math.random() * 30}%` }}
+									style={{ width: VERSE_WIDTHS[(verse - 1) % VERSE_WIDTHS.length] }}
 								/>
 							</div>
 						))}

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -53,17 +53,41 @@ export async function sendWelcomeEmail(
 	await ses.send(command)
 }
 
+/**
+ * Uniform random integer in [0, maxExclusive) drawn from the platform CSPRNG.
+ *
+ * `Math.random()` must not be used for either value below. V8 backs it with a
+ * single xorshift128+ stream per context, so an attacker who collects a handful
+ * of outputs — by requesting codes for an address they control — can recover the
+ * generator state and predict the code or token issued to anyone else served by
+ * the same process. The verification code gates sign-up and the token is the only
+ * credential `/api/preferences` accepts, so both are guessing targets.
+ *
+ * Rejection sampling keeps the result unbiased; a bare `% maxExclusive` would
+ * skew towards the low end of the range.
+ */
+const randomInt = (maxExclusive: number): number => {
+	const limit = Math.floor(0x1_0000_0000 / maxExclusive) * maxExclusive
+	const buffer = new Uint32Array(1)
+	let value: number
+	do {
+		crypto.getRandomValues(buffer)
+		value = buffer[0] as number
+	} while (value >= limit)
+	return value % maxExclusive
+}
+
 export function generateOTP(): string {
 	const min = 10 ** (OTP_LENGTH - 1)
 	const max = 10 ** OTP_LENGTH - 1
-	return Math.floor(min + Math.random() * (max - min + 1)).toString()
+	return (min + randomInt(max - min + 1)).toString()
 }
 
 export function generateToken(): string {
 	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 	let token = ''
 	for (let i = 0; i < TOKEN_LENGTH; i++) {
-		token += chars.charAt(Math.floor(Math.random() * chars.length))
+		token += chars.charAt(randomInt(chars.length))
 	}
 	return token
 }


### PR DESCRIPTION
Found while chasing the failing SonarCloud quality gate — three of the seven unreviewed security hotspots were real.

## The problem

`generateOTP()` and `generateToken()` were both built on `Math.random()`. V8 backs it with a single xorshift128+ stream per context, so an attacker who collects a handful of outputs — by requesting codes for an address they control — can recover the generator state and predict values issued to anyone else served by the same process.

Both are guessing targets:

- the six-digit code gates sign-up in `/api/subscribe`
- the 32-character token is the **only** credential `/api/preferences` accepts (`WHERE token = $1 AND verified = TRUE`)

Predicting a token is enough to read and rewrite another subscriber's email, patron saint and timezone, or unsubscribe them.

## The fix

Both now draw from `crypto.getRandomValues` through a shared helper that rejection-samples rather than taking a modulus, which would otherwise skew results toward the low end of the range.

**Output shape is unchanged** — six digits with a non-zero leading digit, 32 alphanumeric characters — so tokens already stored in `subscribers` keep working and no migration is needed.

Verified over 200k codes and 100k tokens: correct shape and charset, range respected, leading digits within 5% of uniform, zero collisions.

## Also

The readings skeleton drew its placeholder line widths from `Math.random()` during render. That component renders on the server too, so the width React hydrated against never matched the one the server sent. Replaced with fixed widths, which also keeps the ragged-text look deterministic.

## Note on the quality gate

This clears 3 of the 7 hotspots. The remaining 4 are `javascript:S4036` on `scripts/hooks/pre-commit.mjs` and `scripts/install-git-hooks.mjs` — dev-only git hooks spawning `git`/`pnpm` from the developer's own PATH. `sonar-project.properties` already declares the intent to ignore that rule under `scripts/**`, but `sonar.issue.ignore.multicriteria` does not apply to security *hotspots*, only to issues, which is why they keep coming back. They need to be marked Safe once in the SonarCloud UI; that decision then persists.