### PR TITLE
feat(web): link from today's commemorations to the Synaxarium

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -212,7 +212,18 @@ export default async function Home({ searchParams }: HomeProps) {
 			<section className="relative px-6 pb-12">
 				<div className="max-w-4xl mx-auto">
 					<Card>
-						<CardHeader>{t('todaysCommemorations')}</CardHeader>
+						{/* The card shows the day's commemorations by name only; the link is how
+						    you get to the full account of each in the Synaxarium. */}
+						<div className="flex items-center justify-between gap-3 mb-4">
+							<CardHeader className="mb-0">{t('todaysCommemorations')}</CardHeader>
+							<Link
+								href="/synaxarium"
+								className="inline-flex items-center gap-1 shrink-0 text-sm font-medium text-amber-700 dark:text-amber-500 hover:text-amber-800 dark:hover:text-amber-400 transition-colors"
+							>
+								{t('viewSynaxarium')}
+								<ChevronRightIcon className="w-4 h-4 rtl:rotate-180" />
+							</Link>
+						</div>
 						<CardContent>
 							<Suspense
 								fallback={

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -209,6 +209,7 @@
 		"upcomingFeasts": "الأعياد القادمة",
 		"upcomingFasts": "الأصوام القادمة",
 		"todaysCommemorations": "تذكارات اليوم",
+		"viewSynaxarium": "اقرأ السنكسار",
 		"preferCalendarSync": "تفضل مزامنة التقويم؟",
 		"addToCalendar": "أضف إلى تقويم Apple أو Google أو Outlook",
 		"footer": "صَلُّوا بِلَا انقطاعٍ (١تس ٥:١٧)",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -209,6 +209,7 @@
 		"upcomingFeasts": "Upcoming Feasts",
 		"upcomingFasts": "Upcoming Fasts",
 		"todaysCommemorations": "Today's Commemorations",
+		"viewSynaxarium": "Read the Synaxarium",
 		"preferCalendarSync": "Prefer calendar sync?",
 		"addToCalendar": "Add to Apple, Google, or Outlook Calendar",
 		"footer": "Built for the Coptic community",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -209,6 +209,7 @@
 		"upcomingFeasts": "Próximas Fiestas",
 		"upcomingFasts": "Próximos Ayunos",
 		"todaysCommemorations": "Conmemoraciones de Hoy",
+		"viewSynaxarium": "Leer el Sinaxario",
 		"preferCalendarSync": "¿Prefieres sincronizar calendario?",
 		"addToCalendar": "Añadir a calendario de Apple, Google u Outlook",
 		"footer": "Hecho para la comunidad copta",


### PR DESCRIPTION
The "Today's Commemorations" card on the home page names the day's commemorations but offers no way through to the accounts themselves — the only route to the Synaxarium was the offerings grid further up the page.

Adds a jump link in the card header, styled after the existing `viewTodaysReadings` link (amber, chevron, `rtl:rotate-180` so it flips in Arabic), with the label added to all three locales.

Verified in the browser: renders right-aligned in the card header, and navigating carries the selected date through to `/synaxarium?date=2026-07-31`.