### PR TITLE
docs: record what each service covers and what is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ pnpm release
 
 ## Data Sources
 
+> **What's actually covered:** [docs/COVERAGE.md](docs/COVERAGE.md) tracks what each
+> service contains, what is missing from it, and which services don't exist yet.
+
 | Data | Source | Notes |
 |------|--------|-------|
 | **Easter Calculation** | Computus algorithm for Eastern Orthodox Easter | Valid for any year — see [Calendar range](#calendar-range) |

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -15,7 +15,7 @@ marked **unverified** is an inventory judgement that no test enforces yet.
 
 | Service | Route | Languages | State |
 |---|---|---|---|
-| Agpeya (7 hours) | `/agpeya` | en, ar | Complete rite; 17 prose gaps in Arabic |
+| Agpeya (7 hours) | `/agpeya` | en, ar | Complete rite; 17 prose gaps, mostly English stubs |
 | Evening Raising of Incense | `/vespers` | en, ar, cop | Complete for Vespers; **Matins missing entirely** |
 | Tasbeha (annual, 7 days) | `/tasbeha` | en, ar, cop | Annual cycle complete; seasonal cycles missing |
 | Divine Liturgy of St. Basil | `/liturgy` | en, ar, cop | **Skeleton — roughly the second half of the rite** |
@@ -105,25 +105,20 @@ English translations are still being improved**.
 ## Agpeya
 
 All seven hours, plus the three midnight watches. English and Arabic. The rite is
-complete; the gaps are Arabic text that has no source yet.
+complete — every hour, every watch — and psalm versification gaps are **0**: the
+psalter aligns verse-for-verse between the two languages.
 
-**17 prose gaps**, all Arabic, regenerate the list with:
+**17 prose gaps**, and the direction matters: in 13 of them the **English is the
+stub and the Arabic is the fuller text** (`prime.litanies` is en=5 against ar=19;
+`midnight.closing` is en=1 against ar=24). Only `midnight.{1,2,3}.closing` are
+missing Arabic outright. So the remaining Agpeya work is largely *translating into
+English*, not sourcing Arabic. See [GAP-REPORT.md](GAP-REPORT.md) for the table.
+
+Regenerate the list with:
 
 ```bash
 cd packages/data && bun scripts/agpeya-gap-report.ts
 ```
-
-They cluster in two places — the litanies of every hour, and the closings:
-
-```
-prime.litanies, terce.litanies, terce.closing, sext.litanies, none.litanies,
-vespers.litanies, vespers.closing, compline.litanies, compline.closing,
-midnight.opening, midnight.closing,
-midnight.{1,2,3}.litanies, midnight.{1,2,3}.closing
-```
-
-Psalm versification gaps: **0** — the psalter is aligned verse-for-verse between
-English and Arabic.
 
 **No Coptic Agpeya at all.** The hours exist only in English and Arabic.
 
@@ -174,7 +169,8 @@ So a realistic reading of coverage is: **the annual skeleton of four services, o
 of which (the Liturgy) is itself half-built**, with seasonal resolution existing in
 one service only. Closing the gap is less about importing more pages than about the
 conditional-text model that lets one service render correctly across the year — see
-the block schema and resolver work tracked as the core product problem.
+the block schema and resolver work tracked as the core product problem, and
+[GAP-REPORT.md](GAP-REPORT.md) for the full backlog with source availability.
 
 ---
 

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -1,0 +1,210 @@
+# Service coverage
+
+What each service actually contains today, what is missing from it, and which
+services do not exist yet. Written to be honest rather than flattering — the point
+is to know what a user would hit, not to look finished.
+
+Last surveyed: 2026-07-31.
+
+Where a gap is already pinned by a test or a source note, that is linked. Anything
+marked **unverified** is an inventory judgement that no test enforces yet.
+
+---
+
+## Summary
+
+| Service | Route | Languages | State |
+|---|---|---|---|
+| Agpeya (7 hours) | `/agpeya` | en, ar | Complete rite; 17 prose gaps in Arabic |
+| Evening Raising of Incense | `/vespers` | en, ar, cop | Complete for Vespers; **Matins missing entirely** |
+| Tasbeha (annual, 7 days) | `/tasbeha` | en, ar, cop | Annual cycle complete; seasonal cycles missing |
+| Divine Liturgy of St. Basil | `/liturgy` | en, ar, cop | **Skeleton — roughly the second half of the rite** |
+| Synaxarium | `/synaxarium` | en, ar | Complete daily cycle |
+| Katameros readings | `/readings` | en, ar, es, cop | Complete daily cycle |
+
+---
+
+## Divine Liturgy of St. Basil — the least complete
+
+33 sections. It carries the Anaphora well and the front of the Liturgy barely at
+all, so it currently reads as "the Liturgy from the Thanksgiving Prayer onward"
+rather than the Liturgy.
+
+### What is present
+
+The Liturgy of the Faithful is substantially there: Reconciliation, Anaphora,
+Agios, Institution Narrative, Epiclesis, the Seven Short Litanies, Commemoration
+of the Saints, Diptych, the Fraction and prayers after it, the Confession, and the
+prayers through to Submission to the Father.
+
+`pauline`, `catholic`, `praxis`, `daily-psalm` and `gospel` correctly carry no
+stored text — the API resolves them from the day's Katameros at request time. An
+empty `content` on those five is by design, not a gap.
+
+### What is missing
+
+**Everything before the Thanksgiving Prayer.** None of the following exists:
+
+- Vesting and the Prayer of Preparation
+- The Offering of the Lamb (Prothesis) — selection, procession, and the prayers at
+  the altar
+- Absolution of the Ministers
+- The Offertory / Prospherin
+
+**Most of the Liturgy of the Word:**
+
+- The Pauline incense and procession, and the Pauline hymn
+- Responses to the Catholic and the Praxis
+- **The Synaxarium reading** — read after the Praxis. Notable because the
+  Synaxarium data already exists in this repo and is served at `/synaxarium`; this
+  is a wiring gap, not a data gap.
+- The Three Great Litanies (peace, fathers, congregation). `litany-gospel` is
+  present but is a different litany.
+- The Prayer of the Veil
+- The Aspasmos (Adam and Watos) and the Kiss of Peace
+
+**In and after the Anaphora:**
+
+- Congregation and deacon responses are thin. Across the whole service the text
+  attributes 70 lines to the Priest, 53 to the People and 22 to the Deacon, with
+  193 lines unattributed — in the celebrated rite the priest's prayers alternate
+  with responses far more often than that. **Unverified**: no test asserts the
+  expected alternation.
+- Psalm 150 and the communion hymns
+- The Blessing and Dismissal
+
+### Language gaps
+
+- `absolution-to-the-son` has **no Coptic**. The tasbeha.org Three Absolutions page
+  carries no Coptic column. Pinned in `packages/data/src/__tests__/liturgy-parity.test.ts`
+  so nobody "fixes" it by inventing text.
+- **23 of 33 Coptic section titles fall back to English** (`titleLanguage: 'en'`).
+  The prayer text is Coptic; only the headings are English.
+- Coptic scripture depends on which books the Coptic Bible has. Epistles generally
+  resolve; some psalms return a reference with no verses.
+
+---
+
+## Evening Raising of Incense (Vespers)
+
+25 sections, all three languages, complete for the service it covers.
+
+**Missing: the Morning Raising of Incense (Matins).** The data has exactly one
+variant, `evening`. Matins is a distinct service prayed daily and is entirely
+absent — arguably the single largest missing service in the app, since it is prayed
+every morning.
+
+Conditional blocks (`when` on dayTune, season, weekday, commemoration, feast) are
+implemented and resolve at runtime, so the seasonal litanies work.
+
+Per project notes, the **Arabic is the canonical Egyptian text and is solid; some
+English translations are still being improved**.
+
+---
+
+## Agpeya
+
+All seven hours, plus the three midnight watches. English and Arabic. The rite is
+complete; the gaps are Arabic text that has no source yet.
+
+**17 prose gaps**, all Arabic, regenerate the list with:
+
+```bash
+cd packages/data && bun scripts/agpeya-gap-report.ts
+```
+
+They cluster in two places — the litanies of every hour, and the closings:
+
+```
+prime.litanies, terce.litanies, terce.closing, sext.litanies, none.litanies,
+vespers.litanies, vespers.closing, compline.litanies, compline.closing,
+midnight.opening, midnight.closing,
+midnight.{1,2,3}.litanies, midnight.{1,2,3}.closing
+```
+
+Psalm versification gaps: **0** — the psalter is aligned verse-for-verse between
+English and Arabic.
+
+**No Coptic Agpeya at all.** The hours exist only in English and Arabic.
+
+---
+
+## Tasbeha (Midnight Praises)
+
+The annual weekly cycle is complete: seven services (Sunday through Friday Midnight
+Praises, Saturday Vespers Praise), all three languages, 39 ordered sections on
+Sunday plus 20 shared sections.
+
+Missing, per `packages/data/src/en/tasbeha/CORPUS.md`:
+
+- **Kiahk** — the month's own Psalmody. Roughly 20 unique texts (the site's 129
+  count is mostly melody variants of the same 9 Theotokia parts).
+- **Every seasonal cycle** — Great Lent, Resurrection, Theophany, Nativity, Hosanna
+  Sunday, the 29th of the month, Annunciation, Ascension, Apostles. Not yet probed.
+- Two Sunday pages still outstanding (Evol Hetin long form; the Year Round Canticle
+  is a pointer page).
+
+Known fidelity limit: **Arabic-only rows are dropped on import.** The Kiahk
+Expositions carry long Arabic طرح prose with no English or Coptic parallel — one
+page has ~1,900 characters of Arabic alone. The aligned-row schema requires all
+three columns, so that text is discarded. Capturing it needs a per-language
+optional-row model.
+
+---
+
+## The cross-cutting gap: everything here is the annual form
+
+Counting missing *services* understates the distance. Every service implemented
+above is its **annual (ordinary-time) form**. The tradition varies almost all of
+them by season, feast and occasion, and that variation is largely absent:
+
+- **Great Lent** changes the Liturgy's responses, the Psalmody, and the hours.
+- **Kiahk** has its own Psalmody, its own vigil, and its own Liturgy responses.
+- **Pascha and Holy Week** replace the ordinary rite outright.
+- **The Resurrection through Pentecost** carries its own hymns and responses.
+- **Each major feast** has proper doxologies, responses and hymns.
+- **Commemorations** — the saint of the day changes doxologies and the Difnar.
+
+The Incense service is the only one with a working conditional mechanism: its
+sections carry `when` blocks keyed on dayTune, season, weekday, commemoration and
+feast, resolved per request. Nothing else has it. The Liturgy, the Agpeya and the
+Tasbeha all store a single fixed text.
+
+So a realistic reading of coverage is: **the annual skeleton of four services, one
+of which (the Liturgy) is itself half-built**, with seasonal resolution existing in
+one service only. Closing the gap is less about importing more pages than about the
+conditional-text model that lets one service render correctly across the year — see
+the block schema and resolver work tracked as the core product problem.
+
+---
+
+## Services that do not exist at all
+
+Ordered roughly by how often they are prayed.
+
+| Service | Note |
+|---|---|
+| **Morning Raising of Incense (Matins)** | Prayed daily. The incense module has only `evening`. |
+| **Liturgy of St. Gregory** | The second of the three Anaphoras, used on feasts. |
+| **Liturgy of St. Cyril** | The third, used in Kiahk and Great Lent. |
+| **Holy Week (Pascha)** | The largest single body of text in the tradition. |
+| **Kiahk Psalmody and vigil** | See Tasbeha above. |
+| **Doxologies and Difnar** | Per season and per saint of the day; drives much of the daily variation. |
+| **Blessing of the Waters (Laqqan)** | Theophany, Great Friday, the Apostles' feast. |
+| **Funeral rites** | Distinct rites for men, women, children, clergy, and by season. |
+| **Baptism and Chrismation** | |
+| **Matrimony** | Includes the betrothal and crowning rites. |
+| **Unction of the Sick** | The seven prayers. |
+| **Occasional prayers** | Travel, meals, the sick, blessing a home. |
+| **Ordination and consecration rites** | Lowest priority — clergy-facing, rarely read by laity. |
+
+---
+
+## How to keep this honest
+
+- Agpeya: `cd packages/data && bun scripts/agpeya-gap-report.ts` prints current gaps
+  and the exact `KNOWN_PROSE_GAPS` block to paste into the parity test.
+- Liturgy, Tasbeha, Incense: the parity tests in `packages/data/src/__tests__/`
+  fail when languages drift out of alignment, and pin known source gaps explicitly.
+- Anything above marked **unverified** has no test behind it. Prefer converting
+  those into pinned test expectations over trusting this file.

--- a/docs/GAP-REPORT.md
+++ b/docs/GAP-REPORT.md
@@ -1,0 +1,170 @@
+# Gap report — what stands between us and complete liturgical coverage
+
+A backlog, not a status page. [COVERAGE.md](COVERAGE.md) says what each service
+holds today; this says what is missing, how big each piece is, and whether a
+source exists for it.
+
+Surveyed 2026-07-31. Source counts come from the Tasbeha.org hymn library index,
+whose category tree ships inline on `/hymn_library/` — 209 categories, parseable in
+one request. Counts are the site's own hymn counts, not row counts, so treat them
+as scope signals rather than exact work estimates.
+
+---
+
+## Part 1 — gaps inside what we already ship
+
+### Agpeya — the English is the incomplete side
+
+**This corrects an earlier reading.** The 17 prose gaps are not missing Arabic. In
+13 of 17 the Arabic is the fuller text and the **English is a stub**:
+
+| Section | English lines | Arabic lines |
+|---|---|---|
+| `prime.litanies` | 5 | 19 |
+| `terce.litanies` | 4 | 25 |
+| `sext.litanies` | 4 | 26 |
+| `none.litanies` | 4 | 28 |
+| `vespers.litanies` | 4 | 17 |
+| `compline.litanies` | 4 | 16 |
+| `midnight.opening` | 3 | 6 |
+| `midnight.closing` | 1 | 24 |
+| `midnight.{1,2,3}.litanies` | 3 | 18 / 18 / 21 |
+
+Only four go the other way — `midnight.{1,2,3}.closing` have **no Arabic at all**
+(`ar=0`) — plus three closings where Arabic is one line against two or three
+(`terce`, `vespers`, `compline`).
+
+So the Agpeya's remaining work is mostly **translating the Arabic litanies and the
+midnight closing into English**, not sourcing Arabic. The rite itself is complete:
+all seven hours, all three midnight watches, and **0 psalm versification gaps** —
+the psalter aligns verse-for-verse.
+
+**No Coptic Agpeya exists.** The hours are English and Arabic only, and no Coptic
+Agpeya has been sourced. This is the largest single hole in the Agpeya.
+
+Regenerate the list: `cd packages/data && bun scripts/agpeya-gap-report.ts`
+
+### Divine Liturgy — the front half is missing
+
+We hold roughly the Anaphora onward. Absent:
+
+| Missing | Source |
+|---|---|
+| The Offering of the Lamb (Prothesis), vesting, Absolution of the Ministers | cat 222 "The Offertory تقديم الحمل" |
+| Pauline procession and hymn, the Three Great Litanies, Prayer of the Veil, Aspasmos | cat 204 "The Liturgy of the Word" |
+| Communion hymns, Psalm 150, the Blessing and Dismissal | cat 205 "The Liturgy of the Believers" |
+| Deacon responses throughout | cat 227 — 29 hymns |
+| **The Synaxarium reading** | **none needed** — the data already ships at `/synaxarium`; this is wiring |
+
+Also: `absolution-to-the-son` has no Coptic (the source page carries no Coptic
+column — pinned in the parity test), and 23 of 33 Coptic section titles fall back
+to English.
+
+### Evening Incense — Matins is absent
+
+The module has one variant, `evening`. The Morning Raising of Incense is prayed
+daily and does not exist. Source: **cat 83, "Raising Incense of Matins & Vespers",
+17 hymns** — the same category we already drew Vespers from, so the sourcing
+pattern is proven.
+
+### Tasbeha — annual only
+
+Complete for the annual weekly cycle in all three languages. Missing: Kiahk
+(cat 33), and every seasonal cycle — Great Lent, Resurrection, Theophany,
+Nativity, Hosanna Sunday, the 29th of the month, Annunciation, Ascension, Apostles.
+Also "Midnight Psalmody — 7 & 4" (cat 258, 10 hymns).
+
+Known import limit: **Arabic-only rows are dropped**, because the aligned-row
+schema requires all three columns. The Kiahk Expositions carry long Arabic طرح
+prose with no English or Coptic parallel — one page has ~1,900 characters of Arabic
+that we discard. Fixing this needs a per-language optional-row model.
+
+---
+
+## Part 2 — services we do not have
+
+Ordered by how often they are prayed, with source availability.
+
+### Prayed daily or weekly
+
+| Service | Source | Scope |
+|---|---|---|
+| **Morning Raising of Incense (Matins)** | cat 83 | 17 hymns |
+| **Doxologies** (seasonal and per-saint) | cat 40, 71 | Drives much of the daily variation |
+| **Liturgy of St. Gregory** | cat 209 | 20 hymns |
+| **Liturgy of St. Cyril** | cat 210 | 32 hymns |
+
+The two extra Anaphoras are the cheapest large win: the Liturgy shell already
+exists, and Gregory and Cyril differ from Basil mainly in the Anaphora itself.
+
+### Seasonal
+
+| Service | Source | Note |
+|---|---|---|
+| **Holy Pascha Week** | cat 38 | The largest single body of text in the tradition |
+| **Great Lent** | cat 37 | Own hymns plus rite changes to existing services |
+| **Kiahk** | cat 33 | Psalmody, vigil, and Liturgy responses |
+
+### Sacraments and occasional rites
+
+| Service | Source | Scope |
+|---|---|---|
+| **Holy Matrimony (Crowning)** | cat 235 | 41 hymns |
+| **Unction of the Sick (Andeel)** | cat 236 | 37 hymns |
+| **The Sagda (Prostrations)** | cat 237 | 29 hymns — prayed at Pentecost |
+| **General Funeral** | cat 86, 118 | 1 + 11 hymns; the tradition has separate rites per category of departed |
+| **Consecrations** | cat 316 | Churches, altars, vessels |
+| **Preparation of the Holy Myron** | cat 299 | Rare; patriarchal |
+
+### Not available from this source
+
+**Baptism and Chrismation.** The category tree has no baptism entry — zero matches
+across all 209 categories. It sits under "Other Liturgical & Sacramental Services"
+alongside Matrimony and Unction in the tradition, but the source does not carry it.
+Sourcing it means finding another text, not another import run. The same likely
+applies to Ordination.
+
+---
+
+## Part 3 — the gap that is not a content gap
+
+Every service we ship is its **annual form**. The tradition varies nearly all of
+them by season, feast and commemoration, and only the Incense service can express
+that: its sections carry `when` blocks keyed on dayTune, season, weekday,
+commemoration and feast, resolved per request. The Liturgy, Agpeya and Tasbeha each
+store one fixed text.
+
+This matters for sequencing. Importing Kiahk or Lent as *separate services* would
+duplicate the annual text with small deltas and multiply the maintenance surface.
+The conditional-text model — blocks plus a resolver — is what lets one service
+render correctly across the year, and it should land before the seasonal imports,
+not after.
+
+---
+
+## Suggested order
+
+1. **Matins incense** — daily, proven sourcing pattern, one category.
+2. **Agpeya English litanies** — translation of text we already hold, no new source.
+3. **Liturgy front half** — Offertory and Liturgy of the Word; makes `/liturgy` a
+   complete service rather than a partial one, and wires in the Synaxarium reading
+   we already have.
+4. **Conditional-text model** — before any seasonal import.
+5. **St. Gregory and St. Cyril** — reuse the Liturgy shell.
+6. **Seasonal cycles** — Kiahk, Great Lent, Pascha, on top of the model from 4.
+7. **Sacraments** — Matrimony, Unction, Sagda, Funeral.
+8. **Baptism** — blocked on finding a source.
+
+---
+
+## Keeping this current
+
+- Agpeya: `cd packages/data && bun scripts/agpeya-gap-report.ts` regenerates the
+  gap list and the exact allowlist block for `agpeya-parity.test.ts`.
+- There is **no equivalent report for the Liturgy, Tasbeha or Incense**. Their gaps
+  live in prose across `SOURCE.md`, `CORPUS.md` and pinned sets inside the parity
+  tests, which is why assembling this took a survey. Porting the Agpeya script's
+  pattern — report, then paste into a ratcheting allowlist — to the other three
+  would make most of this file generated rather than hand-maintained.
+- The source category tree can be re-read in one request from
+  `https://tasbeha.org/hymn_library/`; the tree is inline in the page.


### PR DESCRIPTION
There was no single answer to "how complete is this". The gaps were spread across a parity test's pinned exceptions, a gap-report script, three `SOURCE.md` files and a corpus survey — reconstructing the honest state of any one service took an afternoon.

`docs/COVERAGE.md` records, per service, what is present, what is missing, and how to regenerate each list. Linked from the README.

## Two findings worth stating plainly

**The Liturgy is roughly its second half.** The Anaphora through the Confession is solid — Reconciliation, Institution, Epiclesis, Seven Short Litanies, Commemoration, Diptych, Fraction, Confession. What is absent is everything before the Thanksgiving Prayer (the Offering of the Lamb, Absolution of the Ministers, the Offertory) and most of the Liturgy of the Word: the Pauline procession and hymn, the Three Great Litanies, the Prayer of the Veil, the Aspasmos — and the Synaxarium reading, which is a wiring gap rather than a data gap, since that data already ships at `/synaxarium`.

Speaker attribution is also thin: 70 Priest lines, 53 People, 22 Deacon, and 193 unattributed. In the celebrated rite the alternation is far denser. Nothing tests this, so it is flagged as unverified rather than asserted.

**Counting missing services understates the distance.** Every service we have is its *annual* form. Great Lent, Kiahk, Pascha, the Resurrection season and each major feast all vary the text, and only the Incense service has a working conditional mechanism (`when` blocks on dayTune/season/weekday/commemoration/feast). The Liturgy, Agpeya and Tasbeha each store one fixed text. So the realistic summary is: the annual skeleton of four services, one of them half-built, with seasonal resolution in exactly one — which makes the conditional-text model the lever, not more imports.

## Already-known gaps, now collected

- Agpeya: 17 Arabic prose gaps (all litanies and closings), 0 psalm versification gaps, no Coptic at all
- Incense: complete for Vespers; **Matins does not exist** — the module has only an `evening` variant, and Matins is prayed daily
- Tasbeha: annual cycle complete in all three languages; Kiahk and every seasonal cycle missing; Arabic-only rows are dropped on import by the aligned-row schema
- Liturgy: `absolution-to-the-son` has no Coptic (pinned in the parity test); 23 of 33 Coptic titles fall back to English

Nothing here changes code — it is documentation of the current state.