### PR TITLE
refactor(data): extract shared liturgical primitives + resolver (conditional stage 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ Roadmap.md
 # SonarQube for IDE — keep shared binding, ignore local state
 .sonarlint/*
 !.sonarlint/connectedMode.json
+
+references/*

--- a/apps/api/src/services/incense.service.ts
+++ b/apps/api/src/services/incense.service.ts
@@ -1,9 +1,8 @@
-import { type DayTune, type NatureSeason, getLiturgicalContext } from '@coptic/core'
+import { getLiturgicalContext } from '@coptic/core'
 import { getIncenseService as getArIncenseService } from '@coptic/data/ar/incense'
+import { type OccasionContext, resolveBlocks } from '@coptic/data/content'
 import { getIncenseService as getCopIncenseService } from '@coptic/data/cop/incense'
 import {
-	type IncenseCondition,
-	type IncenseConditionalBlock,
 	type IncenseContent,
 	type IncenseDailyPsalmSection,
 	type IncenseGospelSection,
@@ -69,42 +68,6 @@ export interface ResolvedIncenseService {
 	date: string
 	copticDate: CopticDate
 	sections: ResolvedIncenseSection[]
-}
-
-// The occasion a service is being prayed on. Drives conditional block resolution.
-// dayTune and season come from the calendar; commemorations/feasts are placeholders for
-// the next stages (saint-of-day, feast overrides).
-interface OccasionContext {
-	dayTune: DayTune
-	season: NatureSeason
-	// Weekday of the liturgical day (0 = Sunday … 6 = Saturday).
-	weekday: number
-	commemorations: string[]
-	feasts: string[]
-}
-
-function matchesCondition(when: IncenseCondition | undefined, ctx: OccasionContext): boolean {
-	if (!when) return true
-	if (when.dayTune && when.dayTune !== ctx.dayTune) return false
-	if (when.season && when.season !== ctx.season) return false
-	if (when.weekday != null) {
-		const wanted = Array.isArray(when.weekday) ? when.weekday : [when.weekday]
-		if (!wanted.includes(ctx.weekday)) return false
-	}
-	if (when.commemoration) {
-		const wanted = Array.isArray(when.commemoration) ? when.commemoration : [when.commemoration]
-		if (!wanted.some((w) => ctx.commemorations.includes(w))) return false
-	}
-	if (when.feast) {
-		const wanted = Array.isArray(when.feast) ? when.feast : [when.feast]
-		if (!wanted.some((w) => ctx.feasts.includes(w))) return false
-	}
-	return true
-}
-
-// Additive resolution — every block whose condition matches is included, in order.
-function resolveBlocks(blocks: IncenseConditionalBlock[], ctx: OccasionContext): IncenseContent[] {
-	return blocks.filter((b) => matchesCondition(b.when, ctx)).flatMap((b) => b.content)
 }
 
 // Rubric for an out-of-season nature litany offered as an optional extra, in the

--- a/docs/CONDITIONAL-RESOLUTION.md
+++ b/docs/CONDITIONAL-RESOLUTION.md
@@ -1,0 +1,206 @@
+# Conditional text resolution — design
+
+Liturgical services are not fixed text. Parts vary by occasion and **compose**: a
+martyr's feast can land on a Sunday inside a fast, and all three affect what is
+prayed. Getting this right is the product; everything else is data entry.
+
+This documents what already works, the three things that break it, and a staged
+plan. It supersedes nothing — the Incense service's block model is the working
+prototype and the starting point.
+
+---
+
+## What works today
+
+The Incense service already resolves conditionally. A section carries either flat
+`content` or `blocks`:
+
+```ts
+interface IncenseConditionalBlock {
+	when?: IncenseCondition   // absent ⇒ always included
+	title?: string
+	content: IncenseContent[]
+}
+
+interface IncenseCondition {
+	dayTune?: 'adam' | 'watos'
+	season?: 'waters' | 'plants' | 'fruits'
+	weekday?: number | number[]
+	commemoration?: string | string[]
+	feast?: string | string[]
+}
+```
+
+Resolution is **additive**: every block whose condition matches is included, in
+order. That is the correct default, and it is what makes composition work — a
+saint's verses and a feast's verses both appear because both matched.
+
+Mutual exclusivity falls out for free when the conditions are themselves exclusive:
+Adam and Watos can never both match, so only one intro survives. No special
+mechanism needed.
+
+---
+
+## Where it breaks
+
+Three cases the current model cannot express. All three are now documented in real
+data, not hypothesised.
+
+### 1. Overlapping conditions on a slot that must yield exactly one
+
+The Fraction prayer is chosen from **thirteen**, by occasion — see
+`packages/data/src/en/liturgy/RITE-STRUCTURE.md`. The occasions overlap:
+
+> Theophany **is** a Lord's feast.
+
+Under additive resolution both the Theophany fraction and the Lord's-feasts
+fraction match, and the service prints two fraction prayers. The conditions cannot
+be made mutually exclusive without every block restating the negation of every
+other — thirteen blocks each carrying "…and not any of the other twelve".
+
+**This slot needs "most specific wins", not "include all".**
+
+### 2. Conditions that are not calendar facts
+
+The rite branches on how many clergy are serving:
+
+```
++  In case of no other Priest is present:      Pray.
++  In the presence of other Priest(s):         Pray. Bless
+THE OTHER PRIEST(S): (if any)                  You Bless
+```
+
+Every condition we support is derived from the date. None of them can express "a
+second priest is present" or "the bishop is serving". This is not an edge case —
+it recurs through the Liturgy (Opening Greeting, Litany of the Gospel, and the
+litanies themselves change with a bishop present).
+
+It is the same *shape* as the Vespers saint-of-the-church picker, which is already
+a user-supplied input rather than a calendar one. So the channel exists; the
+condition vocabulary does not.
+
+### 3. Replacement, not addition
+
+> "During the fasting days of the week, on Saturdays and Sundays of the Great Lent
+> and the feasts of the Cross, the following is said **instead of the above**."
+
+Additive resolution can only express this by giving the *default* block a condition
+that excludes every replacing case. That inverts the maintenance burden: adding a
+new seasonal variant means editing the default's condition too, and forgetting to
+is silent — you get both texts. Same pattern at the Aspasmos.
+
+---
+
+## Proposal
+
+### Resolution mode per section
+
+A section declares how its blocks combine:
+
+```ts
+type ResolutionMode =
+	| 'all'   // default — every matching block, in order (today's behaviour)
+	| 'one'   // the first matching block only
+```
+
+`all` stays the default, so nothing changes for the sections that work today —
+commemorations, saint verses, litanies you add to.
+
+`one` covers the fraction prayers, the seasonal replacements, and the celebrant
+branches. **First match wins, with blocks authored most-specific-first**, and the
+unconditioned block last as the default.
+
+Order-based rather than a numeric `priority` field, because:
+
+- it is greppable — the file reads in the order the resolver applies it;
+- there are no numbers to keep consistent across thirteen blocks in three
+  languages;
+- it is one rule, not two (authors already order blocks meaningfully).
+
+The risk is silent authoring mistakes — an unconditioned block placed early makes
+everything after it dead. That is mechanically detectable, so it becomes a test:
+
+> **In a `one` section, only the final block may omit `when`.** Any earlier
+> unconditioned block makes its successors unreachable.
+
+Worth adding a companion check that every `one` section *has* a terminal
+unconditioned block, so there is always a default and resolution cannot yield
+nothing.
+
+### Two condition namespaces
+
+Keep one flat object — the data already reads that way — but split the vocabulary
+by where the value comes from:
+
+```ts
+interface Condition {
+	// Calendar — derived from the date by the resolver
+	dayTune?: 'adam' | 'watos'
+	season?: string
+	weekday?: number | number[]
+	commemoration?: string | string[]
+	feast?: string | string[]
+
+	// Service configuration — supplied by the caller (reader setting, parish default)
+	celebrants?: 'single' | 'concelebrated'
+	bishopPresent?: boolean
+}
+```
+
+The resolver builds the calendar half from the date, as now, and takes the service
+half from the request. `getIncenseForDate` already accepts
+`selectedCommemorations[]`; this generalises that into one `ServiceContext` object
+rather than growing the parameter list per condition type.
+
+### Where the code lives
+
+The resolver is currently inside `apps/api/src/services/incense.service.ts`. It is
+pure data logic with no HTTP in it, and the Liturgy and Tasbeha need the same
+thing, so it should move to `packages/data/src/content/` alongside the shared
+content types — `resolve.ts` next to `types.ts`. API services then pass an
+occasion and get flattened `content[]` back, exactly as they do now.
+
+This also finishes a cleanup already noted: `role`, section `type`, `Speaker`,
+`ContentLine`, `Condition` and `ConditionalBlock` are generic liturgical
+primitives that still live in `en/incense/index.ts` under `Incense*` names.
+`ContentLine`/`ContentSpeaker` were moved to `content/types.ts` with the Liturgy
+work; the rest should follow and drop the `Incense` prefix.
+
+---
+
+## Staging
+
+Each stage is independently shippable and leaves the app working.
+
+**Stage 0 — extract the primitives.** Move `Condition`, `ConditionalBlock`,
+`SectionRole`, `SectionType` to `packages/data/src/content/`, rename `Incense*` →
+`Liturgical*` keeping aliases so nothing breaks, and move `resolveBlocks` beside
+them. No behaviour change; the Incense output must be byte-identical.
+
+**Stage 1 — `mode: 'one'`.** Add the mode, the resolver branch, and both authoring
+tests. Port the two known replacement cases (Hymn of the Intercessions, Aspasmos)
+off the "default with negated condition" workaround if they use it.
+
+**Stage 2 — service configuration.** Add `celebrants` and `bishopPresent` to the
+vocabulary, thread a `ServiceContext` through the API, expose it as a query
+parameter, and surface it in the reader's settings the way the saint picker is.
+
+**Stage 3 — the fraction prayers.** The first real exclusive set: thirteen blocks
+with stated selection rules, in three languages. This is the proof the model holds,
+and it is bounded — the rules are written down in the reference book.
+
+**Stage 4 — shared hymn library.** Hymns recur across services (the Verses of
+Cymbals is prayed at both Vespers and Matins). Define each once with its blocks and
+reference it by id, so both the content and the resolution are shared rather than
+copied.
+
+---
+
+## What this does not solve
+
+Deciding *which saint* a given day commemorates, and which category (apostles,
+martyrs, fathers, saints) their verses come from, is a data-classification problem
+sitting on free-text Synaxarium entries. The model above consumes a
+`commemoration` key; producing that key reliably is separate work, and partly a
+parish setting rather than a calculation — the church's patron saint is a
+configuration value, not a fact about the date.

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -10,6 +10,10 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
 		},
+		"./content": {
+			"types": "./dist/content/index.d.ts",
+			"import": "./dist/content/index.js"
+		},
 		"./en": {
 			"types": "./dist/en/index.d.ts",
 			"import": "./dist/en/index.js"

--- a/packages/data/src/content/index.ts
+++ b/packages/data/src/content/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Primitives shared by every liturgical service — content lines, section roles,
+ * conditions, and the resolver that turns conditional blocks into flat content.
+ *
+ * See docs/CONDITIONAL-RESOLUTION.md.
+ */
+export type {
+	ContentLine,
+	ContentSpeaker,
+	LiturgicalCondition,
+	LiturgicalConditionalBlock,
+	LiturgicalContent,
+	LiturgicalSectionRole,
+} from './types'
+export { type OccasionContext, matchesCondition, resolveBlocks } from './resolve'

--- a/packages/data/src/content/resolve.ts
+++ b/packages/data/src/content/resolve.ts
@@ -1,0 +1,63 @@
+import type { LiturgicalCondition, LiturgicalConditionalBlock, LiturgicalContent } from './types'
+
+/**
+ * The occasion a service is being prayed on — everything a condition can test.
+ *
+ * Built by the caller: the calendar fields come from the date, `commemorations`
+ * composes the day's celebrations with any the reader selected.
+ */
+export interface OccasionContext {
+	dayTune: string
+	season: string
+	/** Weekday of the liturgical day (0 = Sunday … 6 = Saturday). */
+	weekday: number
+	commemorations: string[]
+	feasts: string[]
+}
+
+/**
+ * Whether a block applies. An absent condition always matches, which is what makes
+ * an unconditioned block the default.
+ *
+ * Each dimension narrows independently: a condition naming both a `dayTune` and a
+ * `feast` applies only where both hold. Array values are "any of".
+ */
+export function matchesCondition(
+	when: LiturgicalCondition | undefined,
+	ctx: OccasionContext,
+): boolean {
+	if (!when) return true
+	if (when.dayTune && when.dayTune !== ctx.dayTune) return false
+	if (when.season && when.season !== ctx.season) return false
+	if (when.weekday != null) {
+		const wanted = Array.isArray(when.weekday) ? when.weekday : [when.weekday]
+		if (!wanted.includes(ctx.weekday)) return false
+	}
+	if (when.commemoration) {
+		const wanted = Array.isArray(when.commemoration) ? when.commemoration : [when.commemoration]
+		if (!wanted.some((w) => ctx.commemorations.includes(w))) return false
+	}
+	if (when.feast) {
+		const wanted = Array.isArray(when.feast) ? when.feast : [when.feast]
+		if (!wanted.some((w) => ctx.feasts.includes(w))) return false
+	}
+	return true
+}
+
+/**
+ * Additive resolution — every block whose condition matches, in order.
+ *
+ * Composition is the point: a saint's verses and a feast's verses both appear
+ * because both matched. Mutual exclusivity needs no mechanism where the conditions
+ * are themselves exclusive, as with Adam and Watos.
+ *
+ * Slots that must yield exactly one — the Fraction prayer is chosen from thirteen
+ * overlapping occasions — need first-match instead. That is Stage 1; see
+ * docs/CONDITIONAL-RESOLUTION.md.
+ */
+export function resolveBlocks(
+	blocks: LiturgicalConditionalBlock[],
+	ctx: OccasionContext,
+): LiturgicalContent[] {
+	return blocks.filter((b) => matchesCondition(b.when, ctx)).flatMap((b) => b.content)
+}

--- a/packages/data/src/content/types.ts
+++ b/packages/data/src/content/types.ts
@@ -1,10 +1,14 @@
 /**
- * How a spoken line is stored, shared by every service that prints one.
+ * The primitives every liturgical service shares: how a line is stored, who says
+ * it, what kind of part a section is, and how a section that varies by occasion
+ * is expressed.
  *
- * The Incense and Liturgy modules each declared these independently and
- * identically. Beyond the duplication, the per-language barrels `export *` from
- * both, and two same-named declarations from different modules are ambiguous —
- * re-exporting one shared declaration is not.
+ * These began inside the Incense module and are not incense-specific. The Liturgy
+ * had redeclared several of them identically, which the per-language barrels then
+ * re-exported ambiguously. Declared once here, the Incense, Liturgy and Tasbeha
+ * modules re-export the same symbols instead of competing declarations.
+ *
+ * See docs/CONDITIONAL-RESOLUTION.md for what these are building toward.
  */
 
 /** Who says the line. Sections prayed by everyone store a plain string instead. */
@@ -15,4 +19,43 @@ export interface ContentLine {
 	text: string
 	/** A staging direction rather than text to pray — rendered, but never aligned across languages. */
 	isRubric?: boolean
+}
+
+/** A line is either prayed by everyone (plain string) or attributed to a speaker. */
+export type LiturgicalContent = string | ContentLine
+
+/** Who a section belongs to in the rite. */
+export type LiturgicalSectionRole = 'all' | 'priest' | 'deacon' | 'congregation'
+
+/**
+ * What a section varies by.
+ *
+ * Two vocabularies in one object: the calendar half is derived from the date by
+ * the resolver, the service half is supplied by the caller — a parish setting or a
+ * reader choice, not a fact about the day. Authors write them together; only the
+ * resolver cares where each value came from.
+ */
+export interface LiturgicalCondition {
+	// ── Calendar ──
+	dayTune?: 'adam' | 'watos'
+	/**
+	 * Agricultural season of the Litany for the Nature, resolved from the Coptic date:
+	 * waters (Paoni 12 – Paopi 9), plants (Paopi 10 – Tobi 10), fruits (Tobi 11 – Paoni 11)
+	 */
+	season?: 'waters' | 'plants' | 'fruits'
+	/** Weekday(s) of the liturgical day the service belongs to (0 = Sunday … 6 = Saturday). */
+	weekday?: number | number[]
+	commemoration?: string | string[]
+	feast?: string | string[]
+}
+
+export interface LiturgicalConditionalBlock {
+	/** Absent ⇒ always matches. In a `one` section this marks the default, and must come last. */
+	when?: LiturgicalCondition
+	/**
+	 * Localized display title, used when the block is surfaced standalone — e.g. an
+	 * out-of-season nature litany offered as an optional extra ("Litany of the Waters").
+	 */
+	title?: string
+	content: LiturgicalContent[]
 }

--- a/packages/data/src/en/incense/index.ts
+++ b/packages/data/src/en/incense/index.ts
@@ -1,14 +1,21 @@
-import type { ContentLine } from '../../content/types'
+import type {
+	LiturgicalCondition,
+	LiturgicalConditionalBlock,
+	LiturgicalContent,
+	LiturgicalSectionRole,
+} from '../../content/types'
 import incenseData from './incense.json'
 
 export type IncenseSectionType = 'prayer' | 'psalm' | 'gospel' | 'litany' | 'creed' | 'daily-psalm'
-export type IncenseSectionRole = 'all' | 'priest' | 'deacon' | 'congregation'
 export type IncenseServiceType = 'evening'
 
 export type { ContentLine, ContentSpeaker } from '../../content/types'
 
-// Content can be a plain string (all speakers) or a structured line with speaker
-export type IncenseContent = string | ContentLine
+// The Incense-prefixed names are kept as aliases of the shared primitives: nothing
+// about a role, a line, or a condition is incense-specific, and the Liturgy and
+// Tasbeha resolve against the same shapes.
+export type IncenseSectionRole = LiturgicalSectionRole
+export type IncenseContent = LiturgicalContent
 
 export interface IncensePsalmRef {
 	psalmNumber: number // LXX numbering
@@ -32,25 +39,9 @@ interface IncenseSectionBase {
 // Resolution is additive: every block whose condition matches the day's context is
 // included, in order. Mutually-exclusive variants (e.g. the Adam vs Watos intro) are
 // expressed as mutually-exclusive conditions, so exactly one matches.
-export interface IncenseCondition {
-	dayTune?: 'adam' | 'watos'
-	// Agricultural season of the Litany for the Nature, resolved from the Coptic date:
-	// waters (Paoni 12 – Paopi 9), plants (Paopi 10 – Tobi 10), fruits (Tobi 11 – Paoni 11)
-	season?: 'waters' | 'plants' | 'fruits'
-	// Weekday(s) of the liturgical day the service belongs to (0 = Sunday … 6 = Saturday).
-	// e.g. the Lord's-Day blessing in the Short Blessing applies only on Sunday (0).
-	weekday?: number | number[]
-	commemoration?: string | string[] // e.g. 'apostles' | 'martyrs' | 'saints' (future)
-	feast?: string | string[] // feast key (future)
-}
+export type IncenseCondition = LiturgicalCondition
 
-export interface IncenseConditionalBlock {
-	when?: IncenseCondition // no `when` ⇒ always included
-	// Localized display title, used when the block is surfaced standalone — e.g. an
-	// out-of-season nature litany offered as an optional extra ("Litany of the Waters").
-	title?: string
-	content: IncenseContent[]
-}
+export type IncenseConditionalBlock = LiturgicalConditionalBlock
 
 export interface IncensePrayerSection extends IncenseSectionBase {
 	type: 'prayer' | 'litany' | 'creed'

--- a/packages/data/src/en/liturgy/index.ts
+++ b/packages/data/src/en/liturgy/index.ts
@@ -1,4 +1,4 @@
-import type { ContentLine } from '../../content/types'
+import type { LiturgicalContent, LiturgicalSectionRole } from '../../content/types'
 import liturgyData from './liturgy.json'
 
 export type LiturgySectionType =
@@ -8,14 +8,14 @@ export type LiturgySectionType =
 	| 'gospel'
 	| 'daily-psalm'
 	| 'epistle'
-export type LiturgySectionRole = 'all' | 'priest' | 'deacon' | 'congregation'
+export type LiturgySectionRole = LiturgicalSectionRole
 export type LiturgyRite = 'basil'
 export type LiturgyLanguage = 'en' | 'ar' | 'cop'
 
 export type { ContentLine, ContentSpeaker } from '../../content/types'
 
 // Content can be a plain string (all speakers) or a structured line with speaker
-export type LiturgyContent = string | ContentLine
+export type LiturgyContent = LiturgicalContent
 
 interface LiturgySectionBase {
 	id: string


### PR DESCRIPTION
Stage 0 of `docs/CONDITIONAL-RESOLUTION.md` (design doc included here). **No behaviour change** — groundwork so the conditional model has one home instead of living inside one service.

## Why

Conditional resolution is the central product problem: services are not fixed text, parts vary by occasion and *compose*. The Incense service already does this well, but the machinery is trapped inside it:

- content lines, section roles, conditions and conditional blocks are declared in `en/incense/index.ts` under `Incense*` names, though nothing about them is incense-specific — the Liturgy had already redeclared several identically, which is what made the per-language barrels ambiguous earlier this week
- `matchesCondition` / `resolveBlocks` live in `apps/api/src/services/incense.service.ts`, are pure data logic with no HTTP in them, and are exactly what the next service would have to copy

## What moves

```
packages/data/src/content/
  types.ts    ContentLine, ContentSpeaker, LiturgicalContent,
              LiturgicalSectionRole, LiturgicalCondition, LiturgicalConditionalBlock
  resolve.ts  matchesCondition, resolveBlocks, OccasionContext
  index.ts    → @coptic/data/content
```

`Incense*` and `Liturgy*` names are retained as aliases, so every existing import still resolves and no caller changed.

## Verification

The promise of this stage is "nothing changes", so it is measured rather than asserted. Baseline captured before any edit: 30 Incense responses — 10 dates chosen to exercise adam/watos weekdays, all three agricultural seasons, a Sunday and a Coptic-29th commemoration day, across all three languages.

```
before: bc4da38892e6973505aa23aca6ed4cdb
after:  bc4da38892e6973505aa23aca6ed4cdb
✓ identical
```

871 unit tests, typecheck, biome and package builds clean.

## What comes next (not in this PR)

Stage 1 adds `mode: 'one'` for slots that must yield exactly one — the Fraction prayer is chosen from thirteen occasions that *overlap* (Theophany is a Lord's feast), which additive resolution cannot express. With it come the two authoring invariants that make ordered blocks safe: only the final block may omit `when`, and a `one` section must end with an unconditioned default.

`LiturgicalCondition` deliberately still carries only the calendar half — `celebrants` / `bishopPresent` land in Stage 2, alongside the resolver support that makes them mean something.